### PR TITLE
Add PySide6 main window with system tray integration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Speech-to-text application package."""
+
+from .main import SpeechToTextApp
+
+__all__ = ["SpeechToTextApp"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,86 @@
+"""Application entry point and orchestration logic."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from PySide6.QtWidgets import QApplication
+
+from .system_tray import SystemTrayController
+from .ui import MainWindow
+
+
+class SpeechToTextApp:
+    """High level controller for the speech-to-text application."""
+
+    def __init__(self, system_tray: Optional[SystemTrayController] = None) -> None:
+        self._qt_app: Optional[QApplication] = None
+        self._window: Optional[MainWindow] = None
+        self._active: bool = False
+        self._is_transcribing: bool = False
+        self._system_tray = system_tray or SystemTrayController()
+        self._system_tray.on_toggle = self._handle_tray_toggle
+
+    @property
+    def system_tray(self) -> SystemTrayController:
+        """Expose the system tray controller instance."""
+
+        return self._system_tray
+
+    def start(self) -> int:
+        """Instantiate the UI and start the Qt event loop."""
+
+        if QApplication.instance() is not None:
+            self._qt_app = QApplication.instance()
+        else:
+            self._qt_app = QApplication(sys.argv)
+
+        self._window = MainWindow()
+        self._window.toggle_activation_requested.connect(self._toggle_activation)
+        self._refresh_view()
+        self._window.show()
+
+        return self._qt_app.exec()
+
+    def _refresh_view(self) -> None:
+        if self._window is None:
+            return
+
+        self._window.set_toggle_button_state(self._active)
+        self._window.set_listening_indicator(self._active)
+        self._window.set_transcribing_indicator(self._is_transcribing)
+        self._system_tray.set_listening_state(self._active)
+
+    def _toggle_activation(self) -> None:
+        """Toggle the listening activation state."""
+
+        self._set_activation_state(not self._active)
+
+    def _set_activation_state(self, active: bool) -> None:
+        if self._active == active:
+            return
+
+        self._active = active
+        if not active:
+            self._is_transcribing = False
+        self._refresh_view()
+
+    def set_transcribing(self, active: bool) -> None:
+        """Public hook to reflect the transcription state in the UI."""
+
+        if self._is_transcribing == active:
+            return
+
+        self._is_transcribing = active
+        if active:
+            self._active = False
+        self._refresh_view()
+
+    def _handle_tray_toggle(self, desired_state: bool) -> None:
+        """Callback invoked when the system tray requests a state change."""
+
+        self._set_activation_state(desired_state)
+
+
+__all__ = ["SpeechToTextApp"]

--- a/app/main.py
+++ b/app/main.py
@@ -74,7 +74,7 @@ class SpeechToTextApp:
 
         self._is_transcribing = active
         if active:
-            self._active = False
+            self._active = True
         self._refresh_view()
 
     def _handle_tray_toggle(self, desired_state: bool) -> None:

--- a/app/system_tray.py
+++ b/app/system_tray.py
@@ -1,0 +1,44 @@
+"""System tray controller for the speech-to-text application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+
+@dataclass
+class SystemTrayController:
+    """Simple system tray controller abstraction.
+
+    The controller exposes a callback that is invoked when the tray requests
+    the listening mode to toggle. This simplified version keeps track of the
+    latest activation state so that the rest of the application can remain in
+    sync with the tray icon.
+    """
+
+    on_toggle: Optional[Callable[[bool], None]] = None
+    _is_listening: bool = field(default=False, init=False)
+
+    def set_listening_state(self, active: bool) -> None:
+        """Persist the activation state for the tray icon.
+
+        Parameters
+        ----------
+        active:
+            ``True`` when the microphone should be marked as active, ``False``
+            otherwise.
+        """
+
+        self._is_listening = active
+
+    def request_toggle(self) -> None:
+        """Simulate a toggle request coming from the system tray."""
+
+        if self.on_toggle is not None:
+            self.on_toggle(not self._is_listening)
+
+    @property
+    def is_listening(self) -> bool:
+        """Return the activation state currently reflected in the tray."""
+
+        return self._is_listening

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,0 +1,73 @@
+"""User interface for the speech-to-text application."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class MainWindow(QMainWindow):
+    """Main application window with status indicators and controls."""
+
+    toggle_activation_requested = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Speech to Text")
+
+        self._listening_label = QLabel("Escuchando: OFF")
+        self._transcribing_label = QLabel("Transcribiendo: OFF")
+        self._status_container = QWidget()
+
+        status_layout = QHBoxLayout(self._status_container)
+        status_layout.addWidget(self._listening_label)
+        status_layout.addWidget(self._transcribing_label)
+        status_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._toggle_button = QPushButton("Escuchar OFF")
+        self._toggle_button.setCheckable(True)
+        self._toggle_button.clicked.connect(
+            lambda _checked: self.toggle_activation_requested.emit()
+        )
+
+        central_widget = QWidget()
+        layout = QVBoxLayout(central_widget)
+        layout.addWidget(self._status_container)
+        layout.addWidget(self._toggle_button)
+        layout.addStretch()
+        layout.setAlignment(self._status_container, Qt.AlignmentFlag.AlignCenter)
+        layout.setAlignment(self._toggle_button, Qt.AlignmentFlag.AlignCenter)
+
+        self.setCentralWidget(central_widget)
+
+    def set_listening_indicator(self, active: bool) -> None:
+        """Update the listening indicator label."""
+
+        state = "ON" if active else "OFF"
+        self._listening_label.setText(f"Escuchando: {state}")
+        self._apply_label_style(self._listening_label, active)
+
+    def set_transcribing_indicator(self, active: bool) -> None:
+        """Update the transcribing indicator label."""
+
+        state = "ON" if active else "OFF"
+        self._transcribing_label.setText(f"Transcribiendo: {state}")
+        self._apply_label_style(self._transcribing_label, active)
+
+    def set_toggle_button_state(self, active: bool) -> None:
+        """Reflect the listening state on the toggle button text and state."""
+
+        self._toggle_button.setChecked(active)
+        self._toggle_button.setText("Escuchar ON" if active else "Escuchar OFF")
+
+    @staticmethod
+    def _apply_label_style(label: QLabel, active: bool) -> None:
+        color = "#27ae60" if active else "#7f8c8d"
+        label.setStyleSheet(f"color: {color}; font-weight: bold;")


### PR DESCRIPTION
## Summary
- create a PySide6 main window with listening/transcribing indicators and a toggle button
- expose view helpers to reflect state changes and emit activation toggle requests
- start the UI from SpeechToTextApp and synchronize the state with the system tray controller

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68db2e08dbbc83288cb294abb7873ddd