### PR TITLE
Display brand SVGs in integrations carousel

### DIFF
--- a/inteliautomake/Edicion/styles.css
+++ b/inteliautomake/Edicion/styles.css
@@ -680,6 +680,62 @@ button {
     font-size: 0.95rem;
 }
 
+.ve-logo-carousel {
+    position: relative;
+    overflow: hidden;
+    padding-block: 0.25rem;
+    mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+    -webkit-mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+}
+
+.ve-logo-track {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    width: max-content;
+    animation: ve-logo-scroll 24s linear infinite;
+}
+
+.ve-logo-carousel:hover .ve-logo-track {
+    animation-play-state: paused;
+}
+
+.ve-logo-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    white-space: nowrap;
+}
+
+.ve-logo-item img {
+    display: block;
+    height: 32px;
+    width: auto;
+    filter: grayscale(1) brightness(1.2);
+    opacity: 0.95;
+}
+
+@keyframes ve-logo-scroll {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ve-logo-track {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}
+
 .ve-dual {
     display: grid;
     gap: 2.5rem;

--- a/inteliautomake/Edicion/styles_hero_fixed.css
+++ b/inteliautomake/Edicion/styles_hero_fixed.css
@@ -680,6 +680,62 @@ button {
     font-size: 0.95rem;
 }
 
+.ve-logo-carousel {
+    position: relative;
+    overflow: hidden;
+    padding-block: 0.25rem;
+    mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+    -webkit-mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+}
+
+.ve-logo-track {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    width: max-content;
+    animation: ve-logo-scroll 24s linear infinite;
+}
+
+.ve-logo-carousel:hover .ve-logo-track {
+    animation-play-state: paused;
+}
+
+.ve-logo-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    white-space: nowrap;
+}
+
+.ve-logo-item img {
+    display: block;
+    height: 32px;
+    width: auto;
+    filter: grayscale(1) brightness(1.2);
+    opacity: 0.95;
+}
+
+@keyframes ve-logo-scroll {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ve-logo-track {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}
+
 .ve-dual {
     display: grid;
     gap: 2.5rem;

--- a/inteliautomake/Edicion/styles_updated_hero.css
+++ b/inteliautomake/Edicion/styles_updated_hero.css
@@ -229,21 +229,77 @@
 }
 
 .ve-logo-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  justify-items: center;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    justify-items: center;
 }
 
 .ve-logo-grid span {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.25rem;
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.25rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    font-size: 0.95rem;
+}
+
+.ve-logo-carousel {
+    position: relative;
+    overflow: hidden;
+    padding-block: 0.25rem;
+    mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+    -webkit-mask-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.9) 88%, transparent);
+}
+
+.ve-logo-track {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    width: max-content;
+    animation: ve-logo-scroll 24s linear infinite;
+}
+
+.ve-logo-carousel:hover .ve-logo-track {
+    animation-play-state: paused;
+}
+
+.ve-logo-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    white-space: nowrap;
+}
+
+.ve-logo-item img {
+    display: block;
+    height: 32px;
+    width: auto;
+    filter: grayscale(1) brightness(1.2);
+    opacity: 0.95;
+}
+
+@keyframes ve-logo-scroll {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ve-logo-track {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
 }
 
 .ve-dual {

--- a/inteliautomake/index.html
+++ b/inteliautomake/index.html
@@ -263,19 +263,33 @@
                         <h3>Conectamos con <strong>más de 8.000</strong> aplicaciones</h3>
                         <p>Integramos Agentics con tu stack actual para mantener sincronizadas todas las operaciones.</p>
                     </div>
-                    <div class="ve-logo-grid" aria-label="Integraciones destacadas">
-                        <span>Google Workspace</span>
-                        <span>Microsoft 365</span>
-                        <span>Slack</span>
-                        <span>Teams</span>
-                        <span>Gmail</span>
-                        <span>Meta</span>
-                        <span>Instagram</span>
-                        <span>WhatsApp</span>
-                        <span>Zendesk</span>
-                        <span>Salesforce</span>
-                        <span>HubSpot</span>
-                        <span>Dropbox</span>
+                    <div class="ve-logo-carousel" aria-label="Integraciones destacadas" role="region">
+                        <div class="ve-logo-track">
+                            <span class="ve-logo-item"><img src="/brand/google.svg" alt="Google" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/openai.svg" alt="OpenAI" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/slack.svg" alt="Slack" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/telegram.svg" alt="Telegram" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/gmail.svg" alt="Gmail" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/meta.svg" alt="Meta" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/instagram.svg" alt="Instagram" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/whatsapp.svg" alt="WhatsApp" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/zendesk.svg" alt="Zendesk" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/salesforce.svg" alt="Salesforce" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/hubspot.svg" alt="HubSpot" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/dropbox.svg" alt="Dropbox" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/google.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/openai.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/slack.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/telegram.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/gmail.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/meta.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/instagram.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/whatsapp.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/zendesk.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/salesforce.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/hubspot.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/dropbox.svg" alt="" loading="lazy"></span>
+                        </div>
                     </div>
                 </div>
 

--- a/inteliautomake/public/index.html
+++ b/inteliautomake/public/index.html
@@ -259,19 +259,33 @@
                         <h3>Conectamos con <strong>más de 8.000</strong> aplicaciones</h3>
                         <p>Integramos Agentics con tu stack actual para mantener sincronizadas todas las operaciones.</p>
                     </div>
-                    <div class="ve-logo-grid" aria-label="Integraciones destacadas">
-                        <span>Google Workspace</span>
-                        <span>Microsoft 365</span>
-                        <span>Slack</span>
-                        <span>Teams</span>
-                        <span>Gmail</span>
-                        <span>Meta</span>
-                        <span>Instagram</span>
-                        <span>WhatsApp</span>
-                        <span>Zendesk</span>
-                        <span>Salesforce</span>
-                        <span>HubSpot</span>
-                        <span>Dropbox</span>
+                    <div class="ve-logo-carousel" aria-label="Integraciones destacadas" role="region">
+                        <div class="ve-logo-track">
+                            <span class="ve-logo-item"><img src="/brand/google.svg" alt="Google" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/openai.svg" alt="OpenAI" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/slack.svg" alt="Slack" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/telegram.svg" alt="Telegram" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/gmail.svg" alt="Gmail" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/meta.svg" alt="Meta" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/instagram.svg" alt="Instagram" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/whatsapp.svg" alt="WhatsApp" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/zendesk.svg" alt="Zendesk" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/salesforce.svg" alt="Salesforce" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/hubspot.svg" alt="HubSpot" loading="lazy"></span>
+                            <span class="ve-logo-item"><img src="/brand/dropbox.svg" alt="Dropbox" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/google.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/openai.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/slack.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/telegram.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/gmail.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/meta.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/instagram.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/whatsapp.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/zendesk.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/salesforce.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/hubspot.svg" alt="" loading="lazy"></span>
+                            <span class="ve-logo-item" aria-hidden="true"><img src="/brand/dropbox.svg" alt="" loading="lazy"></span>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- replace the integrations carousel text labels with brand logo images sourced from `/brand/*.svg`, keeping duplicate slides hidden from assistive tech
- adjust the shared carousel styles so the new logo images render consistently across the different hero variants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69019d574c0483288f5fe82b02aa219b